### PR TITLE
Fix repository URL in moon.mod.json

### DIFF
--- a/moon.mod.json
+++ b/moon.mod.json
@@ -2,7 +2,7 @@
   "name": "Kaida-Amethyst/sdl3",
   "version": "0.1.0",
   "readme": "README.md",
-  "repository": "",
+  "repository": "https://github.com/moonbit-community/sdl3.mbt",
   "license": "Apache-2.0",
   "keywords": [],
   "description": "",


### PR DESCRIPTION
This package is published on Mooncakes; set `repository` in `moon.mod.json` to the canonical GitHub repo URL.